### PR TITLE
nicheWidth user defined + RcppExportsIni.c had 27 SEXP -> now 24 SEXP

### DIFF
--- a/PhyloSim/DESCRIPTION
+++ b/PhyloSim/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
 Suggests:
     knitr
 LinkingTo: Rcpp
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(old_usage = TRUE, markdown = TRUE)
 LazyData: true
 VignetteBuilder: knitr

--- a/PhyloSim/R/RcppExports.R
+++ b/PhyloSim/R/RcppExports.R
@@ -3,7 +3,7 @@
 
 #' Core phylosim model
 #' @export
-callModel <- function(x, y, dispersal, runs, specRate, dens, env, neutral, mort, mortStrength, repro, dispersalCutoff, densityCutoff, seed, envStrength, compStrength, fission, redQueen, redQueenStrength, protracted, airmatR, soilmatR, prunePhylogeny) {
-    .Call(`_PhyloSim_callModel`, x, y, dispersal, runs, specRate, dens, env, neutral, mort, mortStrength, repro, dispersalCutoff, densityCutoff, seed, envStrength, compStrength, fission, redQueen, redQueenStrength, protracted, airmatR, soilmatR, prunePhylogeny)
+callModel <- function(x, y, dispersal, runs, specRate, dens, env, neutral, mort, mortStrength, repro, dispersalCutoff, densityCutoff, seed, envStrength, compStrength, fission, redQueen, redQueenStrength, protracted, airmatR, soilmatR, prunePhylogeny, nicheWidth) {
+    .Call(`_PhyloSim_callModel`, x, y, dispersal, runs, specRate, dens, env, neutral, mort, mortStrength, repro, dispersalCutoff, densityCutoff, seed, envStrength, compStrength, fission, redQueen, redQueenStrength, protracted, airmatR, soilmatR, prunePhylogeny, nicheWidth)
 }
 

--- a/PhyloSim/R/parCreator.R
+++ b/PhyloSim/R/parCreator.R
@@ -7,6 +7,7 @@
 #' @param specRate Integer, Number of Individuals introduced to the community in each generation
 #' @param density Float, determining whether or how strong the density dependence influences the model. By default (density=0) there is no density dependence. The higher the value of the parameter, the stronger is the density dependence.
 #' @param environment Float, determining whether or how strong the environment influences the model.  By default (environment=0) there is no influence of the environment. The higher the value of the parameter, the stronger is the influence of the environment. Environment value must be between 0 and 1.
+#' @param nicheWidth Double, Width (σ) of the Gaussian environmental fitness kernel. Smaller values imply stronger environmental filtering (i.e., only individuals with traits close to the environmental optimum have high fitness). Default: 0.03659906.
 #' @param fitnessActsOn Character, determining how the fitness influences the individuals. Possible inputs are "mortality" (default), "reproduction" or "both"
 #' @param fitnessBaseMortalityRatio Integer, determines the fitness based mortality ratio. Must be greater than or equal to 1.
 #' @param densityCut Integer, defines the effective range of the competition (ignored if density = FALSE)
@@ -26,7 +27,7 @@
 #' @example /inst/examples/parCreator-help.R
 #' @export
 
-createCompletePar <- function(x = 50, y = 50, dispersal = "global", runs = 100, specRate = 1.0, density = 0, environment = 0, fitnessActsOn = "mortality" , fitnessBaseMortalityRatio = 10, densityCut = 1, seed=NULL,  type = "base", fission = 0, redQueen = 0, redQueenStrength = 0, protracted = 0, airmat = 1, scenario = NULL, calculateSummaries = FALSE, convertToBinaryTree = TRUE, prunePhylogeny = TRUE){
+createCompletePar <- function(x = 50, y = 50, dispersal = "global", runs = 100, specRate = 1.0, density = 0, environment = 0, nicheWidth = 0.03659906, fitnessActsOn = "mortality" , fitnessBaseMortalityRatio = 10, densityCut = 1, seed=NULL,  type = "base", fission = 0, redQueen = 0, redQueenStrength = 0, protracted = 0, airmat = 1, scenario = NULL, calculateSummaries = FALSE, convertToBinaryTree = TRUE, prunePhylogeny = TRUE){
     
   soilmat <- 1 # Needs to be defined here as long as it is not
                # implemented in the model
@@ -56,7 +57,7 @@ createCompletePar <- function(x = 50, y = 50, dispersal = "global", runs = 100, 
   if (is.null(seed)) seed = sample(1:10000,1)
   
   par = list(x=x,y=y,dispersal = dispersal, runs = runs, specRate = specRate, 
-             density = density, environment = environment, fitnessActsOn=fitnessActsOn,
+             density = density, environment = environment, nicheWidth = nicheWidth, fitnessActsOn=fitnessActsOn,
              fitnessBaseMortalityRatio=fitnessBaseMortalityRatio, densityCut = densityCut, 
              seed = seed, type = type, scenario = scenario, fission = fission, 
              redQueen = redQueen, redQueenStrength = redQueenStrength, protracted = protracted,

--- a/PhyloSim/R/runSimulation.R
+++ b/PhyloSim/R/runSimulation.R
@@ -57,7 +57,10 @@ runSimulation <- function(par)
         par$environment = T
       }
     }
-    
+
+    if (!is.null(par$nicheWidth) && par$nicheWidth <= 0) {
+      stop("nicheWidth must be a positive number (used as variance in the environmental kernel)")
+    }    
     
     if(par$density == 0 & par$environment == 0)
     {
@@ -94,7 +97,8 @@ runSimulation <- function(par)
                       protracted = par$protracted, 
                       airmatR = par$airmat, 
                       soilmatR = par$soilmat,
-                      prunePhylogeny = par$prunePhylogeny)  
+                      prunePhylogeny = par$prunePhylogeny,
+                      nicheWidth = par$nicheWidth)  
     
     runtime <- as.numeric((proc.time() - ptm)[3])
     

--- a/PhyloSim/man/PhyloSim.Rd
+++ b/PhyloSim/man/PhyloSim.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/PhyloSim-package.R
 \docType{package}
 \name{PhyloSim}
-\alias{PhyloSim}
 \alias{PhyloSim-package}
+\alias{PhyloSim}
 \title{Analysing phylogenetic and biogeographic patterns and inferring species community assembly}
 \description{
 This package is designed to simulate and analyse species community assembly processes. It allows the user to implement different mechanisms of community assembly such as environmental filtering, competitive exclusion or dispersal limitation. These mechanisms can be combined or activated seprately, which allows the user to identify biogeographic or phylogenetic patterns exclusively correlated with a certain mechanism or combination of mechanisms.

--- a/PhyloSim/man/callModel.Rd
+++ b/PhyloSim/man/callModel.Rd
@@ -7,7 +7,7 @@
 callModel(x, y, dispersal, runs, specRate, dens, env, neutral, mort,
   mortStrength, repro, dispersalCutoff, densityCutoff, seed, envStrength,
   compStrength, fission, redQueen, redQueenStrength, protracted, airmatR,
-  soilmatR, prunePhylogeny)
+  soilmatR, prunePhylogeny, nicheWidth)
 }
 \description{
 Core phylosim model

--- a/PhyloSim/man/createCompletePar.Rd
+++ b/PhyloSim/man/createCompletePar.Rd
@@ -5,7 +5,7 @@
 \title{Parameter Generator}
 \usage{
 createCompletePar(x = 50, y = 50, dispersal = "global", runs = 100,
-  specRate = 1, density = 0, environment = 0,
+  specRate = 1, density = 0, environment = 0, nicheWidth = 0.03659906,
   fitnessActsOn = "mortality", fitnessBaseMortalityRatio = 10,
   densityCut = 1, seed = NULL, type = "base", fission = 0,
   redQueen = 0, redQueenStrength = 0, protracted = 0, airmat = 1,
@@ -26,6 +26,8 @@ createCompletePar(x = 50, y = 50, dispersal = "global", runs = 100,
 \item{density}{Float, determining whether or how strong the density dependence influences the model. By default (density=0) there is no density dependence. The higher the value of the parameter, the stronger is the density dependence.}
 
 \item{environment}{Float, determining whether or how strong the environment influences the model.  By default (environment=0) there is no influence of the environment. The higher the value of the parameter, the stronger is the influence of the environment. Environment value must be between 0 and 1.}
+
+\item{nicheWidth}{Double, Width (σ) of the Gaussian environmental fitness kernel. Smaller values imply stronger environmental filtering (i.e., only individuals with traits close to the environmental optimum have high fitness). Default: 0.03659906.}
 
 \item{fitnessActsOn}{Character, determining how the fitness influences the individuals. Possible inputs are "mortality" (default), "reproduction" or "both"}
 

--- a/PhyloSim/src/Grid.cpp
+++ b/PhyloSim/src/Grid.cpp
@@ -76,7 +76,7 @@ Landscape::Landscape(int xsize, int ysize, int type, bool neutral, bool dd, bool
                      int DensityCutoff, unsigned int mortalityStrength,
                      double envStrength, double compStrength, int fission, double redQueen, double redQueenStrength,
                      int protracted,
-                     std::vector<double> airmat, std::vector<double> soilmat) {
+                     std::vector<double> airmat, std::vector<double> soilmat, double nicheWidth) {
 
     m_Cutoff = dispersalCutoff;
     m_Neutral = neutral;
@@ -99,6 +99,7 @@ Landscape::Landscape(int xsize, int ysize, int type, bool neutral, bool dd, bool
     m_redQueen = redQueen;
     m_redQueenStrength = redQueenStrength;
     m_protracted = protracted;
+    m_nicheWidth = nicheWidth;
 
     //	func.seedrand(1500);
 
@@ -123,6 +124,7 @@ Landscape::Landscape(int xsize, int ysize, int type, bool neutral, bool dd, bool
             this->m_Individuals[cols][rows].m_dispersalDistance = m_Cutoff / 2.0;
             this->m_Individuals[cols][rows].m_envStrength = m_envStrength;
             this->m_Individuals[cols][rows].m_compStrength = m_compStrength;
+            this->m_Individuals[cols][rows].m_nicheWidth = m_nicheWidth;
 
             //this->individuals[cols][rows].Species->date_of_extinction = runs;
         }
@@ -235,10 +237,10 @@ GlobalEnvironment::GlobalEnvironment(int xsize, int ysize, int type, bool neutra
                                      bool repro, unsigned int runs, double specRate, int dispersalCutoff,
                                      int densityCutoff, unsigned int mortalityStrength, double envStrength,
                                      double compStrength, int fission, double redQueen, double redQueenStrength,
-                                     int protracted, std::vector<double> airmat, std::vector<double> soilmat) :
+                                     int protracted, std::vector<double> airmat, std::vector<double> soilmat, double nicheWidth) :
         Landscape(xsize, ysize, type, neutral, dd, env, mort, repro, runs, specRate, dispersalCutoff, densityCutoff,
                   mortalityStrength, envStrength, compStrength, fission, redQueen, redQueenStrength, protracted, airmat,
-                  soilmat) {
+                  soilmat, nicheWidth) {
 
 }
 
@@ -329,7 +331,7 @@ void GlobalEnvironment::reproduce(unsigned int generation) {
                 for (int kernel_y = 0; kernel_y < m_Ydimensions; kernel_y++) {
                     weights[array_length] = m_Individuals[kernel_x][kernel_y].getFitness(
                             m_Environment[kernel_x * m_Ydimensions + kernel_y].first, m_Env, m_DD, generation,
-                            m_redQueenStrength, m_redQueen);
+                            m_redQueenStrength, m_redQueen, m_nicheWidth);
                     seedSum += weights[array_length];
                     array_length++;
                 }
@@ -366,7 +368,7 @@ void GlobalEnvironment::reproduce(unsigned int generation) {
             if (m_mortality && event % m_mortalityStrength != 0) {
                 double weight = m_Individuals[x_coordinate][y_coordinate].getFitness(
                         m_Environment[x_coordinate * m_Ydimensions + y_coordinate].first, m_Env, m_DD, generation,
-                        m_redQueenStrength, m_redQueen);
+                        m_redQueenStrength, m_redQueen, m_nicheWidth);
                 // important!! the frequency in relation to the base mortality controls the intensity of the mechanisms
                 double chanceOfDeath = m_RandomGenerator.randomDouble(0.0, 1.0);
                 //std::cout<<weight<<"\n"; // DEBUG
@@ -578,10 +580,10 @@ LocalEnvironment::LocalEnvironment(int xsize, int ysize, int type, bool neutral,
                                    bool repro, unsigned int runs, double specRate, int dispersalCutoff,
                                    int densityCutoff, unsigned int mortalityStrength, double envStrength,
                                    double compStrength, int fission, double redQueen, double redQueenStrength,
-                                   int protracted, std::vector<double> airmat, std::vector<double> soilmat) :
+                                   int protracted, std::vector<double> airmat, std::vector<double> soilmat, double nicheWidth) :
         Landscape(xsize, ysize, type, neutral, dd, env, mort, repro, runs, specRate, dispersalCutoff, densityCutoff,
                   mortalityStrength, envStrength, compStrength, fission, redQueen, redQueenStrength, protracted, airmat,
-                  soilmat) {
+                  soilmat, nicheWidth) {
 
 }
 
@@ -630,7 +632,7 @@ void LocalEnvironment::reproduce(unsigned int generation) {
         if (m_mortality && event % m_mortalityStrength != 0) {
             double weight = m_Individuals[x_coordinate][y_coordinate].getFitness(
                     m_Environment[x_coordinate * m_Ydimensions + y_coordinate].first, m_Env, m_DD, generation,
-                    m_redQueenStrength, m_redQueen);
+                    m_redQueenStrength, m_redQueen, m_nicheWidth);
             double chanceOfDeath = m_RandomGenerator.randomDouble(0.0, 1.0);
             if (weight > chanceOfDeath) continue;
         }
@@ -666,7 +668,8 @@ void LocalEnvironment::reproduce(unsigned int generation) {
                                                                                                            kernel_y].first,
                                                                                              m_Env, m_DD, generation,
                                                                                              m_redQueenStrength,
-                                                                                             m_redQueen);
+                                                                                             m_redQueen,
+                                                                                             m_nicheWidth);
                     } else if (m_mortality) {
                         weights[array_length] = m_Individuals[kernel_x][kernel_y].dispersal(m_Dispersal_type,
                                                                                             m_Individuals[kernel_x][kernel_y].euclidian_distance(

--- a/PhyloSim/src/Grid.h
+++ b/PhyloSim/src/Grid.h
@@ -52,7 +52,7 @@ public:
     double m_Speciation_Rate;
 
     double cellsWithinDensityCutoff;
-
+    double m_nicheWidth;
     double m_envStrength;
     double m_compStrength;
     int m_fission;
@@ -75,7 +75,7 @@ public:
               bool dd, bool env, bool mort, bool repro, unsigned int simulationEnd, double specRate,
               int dispersalCutoff, int densityCutoff, unsigned int mortalityStrength, double envStrength,
               double compStrength, int fission, double redQueen, double redQueenStrength, int protracted,
-              std::vector<double> airmat, std::vector<double> soilmat);
+              std::vector<double> airmat, std::vector<double> soilmat, double nicheWidth);
 
     virtual ~Landscape();
 
@@ -111,7 +111,7 @@ public:
                       unsigned int runs, double specRate, int dispersalCutoff, int densityCutoff,
                       unsigned int mortalityStrength,
                       double envStrength, double compStrength, int fission, double redQueen, double redQueenStrength,
-                      int protracted, std::vector<double> airmat, std::vector<double> soilmat);
+                      int protracted, std::vector<double> airmat, std::vector<double> soilmat, double nicheWidth);
 
     virtual ~GlobalEnvironment();
 
@@ -126,7 +126,7 @@ public:
                      unsigned int runs, double specRate, int dispersalCutoff, int densityCutoff,
                      unsigned int mortalityStrength,
                      double envStrength, double compStrength, int fission, double redQueen, double redQueenStrength,
-                     int protracted, std::vector<double> airmat, std::vector<double> soilmat);
+                     int protracted, std::vector<double> airmat, std::vector<double> soilmat, double nicheWidth);
 
     virtual ~LocalEnvironment();
 

--- a/PhyloSim/src/Individual.cpp
+++ b/PhyloSim/src/Individual.cpp
@@ -124,12 +124,12 @@ double Individual::dispersal(int dispersal_type, double distance) {
 
 
 double Individual::getSeedsTo(int rel_x, int rel_y, int dispersal_type, double temp, bool env, bool dd, int generation,
-                              double redQueenStrength, double redQueen) {
+                              double redQueenStrength, double redQueen, double nicheWidth) {
     double dispersal_weight = 0.0;
     dispersal_weight = dispersal(dispersal_type, euclidian_distance(rel_x, rel_y)); // Kernel or NN
 
     if (env || dd) {
-        double fitness_weight = getFitness(temp, env, dd, generation, redQueenStrength, redQueen);
+        double fitness_weight = getFitness(temp, env, dd, generation, redQueenStrength, redQueen, nicheWidth);
         return (dispersal_weight * fitness_weight);
     } else {
         return (dispersal_weight);
@@ -141,9 +141,10 @@ double Individual::getSeedsTo(int rel_x, int rel_y, int dispersal_type, double t
 * @param temp environmental parameter
 * @param env environment acting
 * @param dd density acting
+* @param nicheWidth variance for the environmental fitness kernel
 * @return Fitness
 */
-double Individual::getFitness(double temp, bool env, bool dd, int generation, double redQueenStrength, double redQueen) {
+double Individual::getFitness(double temp, bool env, bool dd, int generation, double redQueenStrength, double redQueen, double nicheWidth) {
     double out = (DBL_MIN * 100.0); // TODO: Why this?
 
     if (env) out += m_envStrength * exp(-0.5 * pow((temp - m_Mean) / m_nicheWidth, 2.0)) + 1 - m_envStrength; // environmental niche

--- a/PhyloSim/src/Individual.h
+++ b/PhyloSim/src/Individual.h
@@ -67,9 +67,9 @@ public:
     void evolveDuringSpeciation();
 
     double getSeedsTo(int rel_x, int rel_y, int dispersal_type, double temp, bool env, bool dd, int generation,
-                      double redQueenStrength, double redQueen);
+                      double redQueenStrength, double redQueen, double nicheWidth);
 
-    double getFitness(double temp, bool env, bool dd, int generation, double redQueenStrength, double redQueen);
+    double getFitness(double temp, bool env, bool dd, int generation, double redQueenStrength, double redQueen, double nicheWidth);
 
 
     double dispersal(int dispersal_type, double distance);  // 1 for kernel, 2 for nearest neighbor, 3 for global

--- a/PhyloSim/src/Main.cpp
+++ b/PhyloSim/src/Main.cpp
@@ -72,6 +72,7 @@ int main() {
     int protracted = 0;
     std::vector<double> airmat(1);
     std::vector<double> soilmat(1);
+    double nicheWidth = 0.03659906; // initial value, when nicheWidth was fixed
     bool prunePhylogeny = 1;
 
     RandomGen ran;
@@ -87,7 +88,7 @@ int main() {
 
     PhylSimModel Model(x, y, dispersal, runs, specRate, dens, env, neutral, mort,
                        mortStrength, repro, dispersalCutoff, densityCutoff, saveLoc, envStrength, compStrength, fission,
-                       redQueen, redQueenStrength, protracted, airmat, soilmat);
+                       redQueen, redQueenStrength, protracted, airmat, soilmat, nicheWidth);
     Model.update(runs);
 
     if (prunePhylogeny) {

--- a/PhyloSim/src/PhylSimModel.cpp
+++ b/PhyloSim/src/PhylSimModel.cpp
@@ -22,7 +22,7 @@ PhylSimModel::PhylSimModel(int X, int Y, int dispersal, int simulationEnd, doubl
                            int densityCutoff, std::string saveLocation, double envStrength, double compStrength,
                            int fission,
                            double redQueen, double redQueenStrength, int protracted, std::vector<double> airmat,
-                           std::vector<double> soilmat) {
+                           std::vector<double> soilmat, double nicheWidth) {
 
 #ifdef DEBUG
     std::cout<<"Running simulation with \n";
@@ -35,13 +35,13 @@ PhylSimModel::PhylSimModel(int X, int Y, int dispersal, int simulationEnd, doubl
     if (dispersal == 1) {
         m_Global = new GlobalEnvironment(X, Y, dispersal, neutral, dens, env, mort, repro, simulationEnd, specRate,
                                          dispersalCutoff, densityCutoff, mortalityStrength, envStrength, compStrength,
-                                         fission, redQueen, redQueenStrength, protracted, airmat, soilmat);
+                                         fission, redQueen, redQueenStrength, protracted, airmat, soilmat, nicheWidth);
         m_Local = NULL;
     } else if (dispersal == 2 || dispersal == 3) {
         m_Global = NULL;
         m_Local = new LocalEnvironment(X, Y, dispersal, neutral, dens, env, mort, repro, simulationEnd, specRate,
                                        dispersalCutoff, densityCutoff, mortalityStrength, envStrength, compStrength,
-                                       fission, redQueen, redQueenStrength, protracted, airmat, soilmat);
+                                       fission, redQueen, redQueenStrength, protracted, airmat, soilmat, nicheWidth);
     }
 
     timeStep = 0;

--- a/PhyloSim/src/PhylSimModel.h
+++ b/PhyloSim/src/PhylSimModel.h
@@ -28,7 +28,7 @@ public:
                  bool env, bool neutral, bool mort, int mortStrength, bool repro, int dispersalCutoff,
                  int densityCutoff, std::string saveLocation, double envStrength, double compStrength,
                  int fission, double redQueen, double redQueenStrength, int protracted, std::vector<double> airmat,
-                 std::vector<double> soilmat);
+                 std::vector<double> soilmat, double nicheWidth);
 
     ~PhylSimModel();
 

--- a/PhyloSim/src/PhylSimModelInterface.cpp
+++ b/PhyloSim/src/PhylSimModelInterface.cpp
@@ -29,7 +29,7 @@ using namespace Rcpp;
 List callModel(int x, int y, int dispersal, IntegerVector runs, double specRate, bool dens, bool env, bool neutral,
                bool mort, int mortStrength, bool repro, int dispersalCutoff, int densityCutoff, int seed,
                double envStrength, double compStrength, int fission, double redQueen, double redQueenStrength,
-               int protracted, NumericVector airmatR, NumericVector soilmatR, bool prunePhylogeny) {
+               int protracted, NumericVector airmatR, NumericVector soilmatR, bool prunePhylogeny, double nicheWidth) {
 #ifdef DEBUG
     std::ofstream debugFile;
     debugFile.open("debug.txt");
@@ -58,6 +58,7 @@ List callModel(int x, int y, int dispersal, IntegerVector runs, double specRate,
     debugFile << "airmatR = " << airmatR.begin() <<", " << airmatR.end() << ";" << std::endl;
     debugFile << "NumericVector airmatR = " << soilmatR << ";" << std::endl;
     debugFile << "soilmatR = " << soilmatR.begin() <<", " << soilmatR.end() << ";" << std::endl;
+    debugFile << "double nicheWidth = " << nicheWidth << ";" << std::endl;
     debugFile.close();
 #endif
 
@@ -76,7 +77,7 @@ List callModel(int x, int y, int dispersal, IntegerVector runs, double specRate,
 
     PhylSimModel phylSimModel(x, y, dispersal, runs[nRuns - 1], specRate, dens, env, neutral, mort, mortStrength, repro,
                               dispersalCutoff, densityCutoff, tempSaveLoc, envStrength, compStrength, fission, redQueen,
-                              redQueenStrength, protracted, airmat, soilmat);
+                              redQueenStrength, protracted, airmat, soilmat, nicheWidth);
 
 
     for (int step = 0; step < nRuns; step++) {

--- a/PhyloSim/src/RcppExportsIni.c
+++ b/PhyloSim/src/RcppExportsIni.c
@@ -15,10 +15,10 @@ See also comments here https://github.com/florianhartig/BayesianTools/issues/31
 extern SEXP _PhyloSim_callModel(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP,
                                 SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP,
                                 SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP,
-                                SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+                                SEXP, SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
-        {"_PhyloSim_callModel", (DL_FUNC) & _PhyloSim_callModel, 23},
+        {"_PhyloSim_callModel", (DL_FUNC) & _PhyloSim_callModel, 24},
         {NULL,                  NULL,                            0}
 };
 


### PR DESCRIPTION
the nicheWidth can now be set in createCompletePar and works properly. The default is the old fixed value 0.0365 ....

a simple code for testing: notice, same seed and same settings but nicheWidth result in different species pattern.

par1 <- createCompletePar(x = 50,y = 50, dispersal = 1, runs = c(1000,2000,3000,4000), specRate = 2, density = 0.9, environment = 0.8, nicheWidth = .05, fitnessActsOn = "mortality", fitnessBaseMortalityRatio = 10, densityCut = 1, seed = 20250624, type = "base", fission = 0, redQueen = 0, redQueenStrength = 0, protracted = 0, scenario = "test") par2 <- createCompletePar(x = 50,
                  y = 50, dispersal = 1, runs = c(1000,2000,3000,4000), specRate = 2, density = 0.9, environment = 0.8, nicheWidth = .1, fitnessActsOn = "mortality", fitnessBaseMortalityRatio = 10, densityCut = 1, seed = 20250624, type = "base", fission = 0, redQueen = 0, redQueenStrength = 0, protracted = 0, scenario = "zorro", calculateSummaries = FALSE, convertToBinaryTree = TRUE, prunePhylogeny = TRUE)
parlist <- list(par1, par2)
run1 <- runSimulationBatch(pars = parlist, parallel = 2) par(mfrow = c(4,2), pty = "s", mar = c(1,1,1,1))
image(run1[[1]]$Output[[1]]$specMat)
image(run1[[2]]$Output[[1]]$specMat)
image(run1[[1]]$Output[[2]]$specMat)
image(run1[[2]]$Output[[2]]$specMat)
image(run1[[1]]$Output[[3]]$specMat)
image(run1[[2]]$Output[[3]]$specMat)
image(run1[[1]]$Output[[4]]$specMat)
image(run1[[2]]$Output[[4]]$specMat)